### PR TITLE
✨ Update typography

### DIFF
--- a/components/molecules/section-header.tsx
+++ b/components/molecules/section-header.tsx
@@ -15,7 +15,7 @@ const headingTags: Record<SectionHeaderVariant, 'h1' | 'h2' | 'h3'> = {
   small: 'h3',
 };
 
-const headingSizes: Record<SectionHeaderVariant, string> = {
+const headingClasses: Record<SectionHeaderVariant, string> = {
   large:
     'text-display-medium lg:text-display-large font-serif lg:max-w-(--breakpoint-lg)',
   medium:
@@ -39,7 +39,7 @@ export function SectionHeader({
       <small className="text-body-medium font-semibold tracking-widest uppercase">
         {kicker}
       </small>
-      <Heading className={headingSizes[size]}>{heading}</Heading>
+      <Heading className={headingClasses[size]}>{heading}</Heading>
       <p className="leading-relaxed lg:max-w-prose">{subheading}</p>
     </header>
   );

--- a/components/molecules/section-header.tsx
+++ b/components/molecules/section-header.tsx
@@ -1,16 +1,22 @@
+import { mergeTailwindClassNames as cn } from '@/lib/utils';
+
 interface SectionHeaderProps {
+  className?: string;
   kicker?: string;
   heading: string;
   subheading?: string;
 }
 
 export function SectionHeader({
+  className,
   kicker,
   heading,
   subheading,
 }: SectionHeaderProps) {
   return (
-    <header className="flex flex-col items-center gap-6 text-center">
+    <header
+      className={cn('flex flex-col items-center gap-6 text-center', className)}
+    >
       <small className="text-body-medium font-semibold tracking-widest uppercase">
         {kicker}
       </small>

--- a/components/molecules/section-header.tsx
+++ b/components/molecules/section-header.tsx
@@ -17,10 +17,11 @@ const headingTags: Record<SectionHeaderVariant, 'h1' | 'h2' | 'h3'> = {
 
 const headingClasses: Record<SectionHeaderVariant, string> = {
   large:
-    'text-display-medium lg:text-display-large font-serif lg:max-w-(--breakpoint-lg)',
+    'text-display-medium text-foreground-brand-default lg:text-display-large font-serif lg:max-w-(--breakpoint-lg)',
   medium:
-    'text-display-small lg:text-display-medium font-serif lg:max-w-(--breakpoint-md)',
-  small: 'text-display-small font-serif lg:max-w-(--breakpoint-sm)',
+    'text-display-small text-foreground-brand-default lg:text-display-medium font-serif lg:max-w-(--breakpoint-md)',
+  small:
+    'text-display-small text-foreground-brand-default font-serif lg:max-w-(--breakpoint-sm)',
 };
 
 export function SectionHeader({
@@ -39,7 +40,9 @@ export function SectionHeader({
       <small className="text-body-medium font-semibold tracking-widest uppercase">
         {kicker}
       </small>
-      <Heading className={headingClasses[size]}>{heading}</Heading>
+      <Heading data-slot="heading" className={headingClasses[size]}>
+        {heading}
+      </Heading>
       <p className="leading-relaxed lg:max-w-prose">{subheading}</p>
     </header>
   );

--- a/components/molecules/section-header.tsx
+++ b/components/molecules/section-header.tsx
@@ -1,18 +1,37 @@
 import { mergeTailwindClassNames as cn } from '@/lib/utils';
 
+type SectionHeaderVariant = 'large' | 'medium' | 'small';
 interface SectionHeaderProps {
   className?: string;
-  kicker?: string;
   heading: string;
+  kicker?: string;
+  size?: SectionHeaderVariant;
   subheading?: string;
 }
 
+const headingTags: Record<SectionHeaderVariant, 'h1' | 'h2' | 'h3'> = {
+  large: 'h1',
+  medium: 'h2',
+  small: 'h3',
+};
+
+const headingSizes: Record<SectionHeaderVariant, string> = {
+  large:
+    'text-display-medium lg:text-display-large font-serif lg:max-w-(--breakpoint-lg)',
+  medium:
+    'text-display-small lg:text-display-medium font-serif lg:max-w-(--breakpoint-md)',
+  small: 'text-display-small font-serif lg:max-w-(--breakpoint-sm)',
+};
+
 export function SectionHeader({
   className,
-  kicker,
   heading,
+  kicker,
+  size = 'large',
   subheading,
 }: SectionHeaderProps) {
+  const Heading = headingTags[size];
+
   return (
     <header
       className={cn('flex flex-col items-center gap-6 text-center', className)}
@@ -20,9 +39,7 @@ export function SectionHeader({
       <small className="text-body-medium font-semibold tracking-widest uppercase">
         {kicker}
       </small>
-      <h1 className="text-foreground-brand-default text-display-medium lg:text-display-large font-serif lg:max-w-(--breakpoint-md)">
-        {heading}
-      </h1>
+      <Heading className={headingSizes[size]}>{heading}</Heading>
       <p className="leading-relaxed lg:max-w-prose">{subheading}</p>
     </header>
   );

--- a/components/organisms/hero.tsx
+++ b/components/organisms/hero.tsx
@@ -1,5 +1,6 @@
 import { useParallax } from '@/hooks/use-parallax';
 import { motion } from 'motion/react';
+import { SectionHeader } from '../molecules/section-header';
 
 interface HeroProps {
   title: string;
@@ -20,9 +21,10 @@ export function Hero({ title, image }: HeroProps) {
         style={{ y, height: '120%' }}
         className="absolute inset-0 w-full object-cover"
       />
-      <h1 className="text-foreground-neutral-inverse text-display-small lg:text-display-large z-10 max-w-(--breakpoint-md) px-8 font-serif leading-snug lg:max-w-(--breakpoint-lg) lg:leading-tight">
-        {title}
-      </h1>
+      <SectionHeader
+        className="text-foreground-neutral-inverse z-10 max-w-(--breakpoint-md) px-8 font-serif lg:max-w-(--breakpoint-lg)"
+        heading={title}
+      />
     </section>
   );
 }

--- a/components/organisms/hero.tsx
+++ b/components/organisms/hero.tsx
@@ -22,7 +22,7 @@ export function Hero({ title, image }: HeroProps) {
         className="absolute inset-0 w-full object-cover"
       />
       <SectionHeader
-        className="text-foreground-neutral-inverse z-10 max-w-(--breakpoint-md) px-8 font-serif lg:max-w-(--breakpoint-lg)"
+        className="text-foreground-neutral-inverse **:data-[slot=heading]:text-foreground-neutral-inverse z-10 max-w-(--breakpoint-md) px-8 font-serif lg:max-w-(--breakpoint-lg)"
         heading={title}
       />
     </section>

--- a/components/organisms/hero.tsx
+++ b/components/organisms/hero.tsx
@@ -1,6 +1,6 @@
+import { SectionHeader } from '@/components/molecules/section-header';
 import { useParallax } from '@/hooks/use-parallax';
 import { motion } from 'motion/react';
-import { SectionHeader } from '../molecules/section-header';
 
 interface HeroProps {
   title: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "quintadonairia",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.2",
+      "version": "1.2.0",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -28,5 +28,5 @@
     "tailwindcss": "^4.1.11",
     "typescript": "^6.0.3"
   },
-  "version": "1.1.2"
+  "version": "1.2.0"
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -11,7 +11,7 @@ export default function Document() {
         <meta name="theme-color" content="#faf6f0" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
-          href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&family=Playfair+Display:wght@400;600&display=swap&family=Fraunces:wght@400&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap&family=Fraunces:opsz,wght,SOFT,WONK@9..144,300,40,1&display=swap"
           rel="stylesheet"
         />
         <link rel="icon" href="/favicon.ico" sizes="32x32" />

--- a/pages/contacts.tsx
+++ b/pages/contacts.tsx
@@ -1,4 +1,5 @@
 import { Tooltip } from '@/components/atoms/tooltip';
+import { SectionHeader } from '@/components/molecules/section-header';
 import { Hero } from '@/components/organisms/hero';
 import { useTranslation } from '@/contexts/translation-context';
 import { FacebookLogo, Info, InstagramLogo } from '@phosphor-icons/react';
@@ -20,10 +21,11 @@ export default function Contacts() {
       <section className="flex flex-col items-center gap-16 px-6 py-16 lg:flex-row lg:p-24">
         <div className="flex flex-col gap-12">
           <div className="flex flex-col gap-2">
-            <h1 className="text-foreground-brand-default text-title-large lg:text-display-small font-serif">
-              {t.contacts.heading}
-            </h1>
-            <p>{t.contacts.subheading}</p>
+            <SectionHeader
+              heading={t.contacts.heading}
+              subheading={t.contacts.subheading}
+              size="medium"
+            />
           </div>
           <div className="flex flex-col gap-6">
             <div className="flex flex-col gap-1">

--- a/pages/experiences.tsx
+++ b/pages/experiences.tsx
@@ -23,6 +23,7 @@ export default function Experiences() {
         <SectionHeader
           heading={t.experiences.heading}
           subheading={t.experiences.subheading}
+          size="medium"
         />
       </Container>
       <Split direction="reverse">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -20,6 +20,7 @@ export default function Home() {
         <SectionHeader
           kicker={t.home.lodging.kicker}
           heading={t.home.lodging.heading}
+          size="medium"
         />
         <div className="flex flex-col items-center justify-between gap-8 lg:flex-row lg:gap-24">
           <img
@@ -45,6 +46,7 @@ export default function Home() {
         <SectionHeader
           kicker={t.home.experiences.kicker}
           heading={t.home.experiences.heading}
+          size="medium"
         />
         <Gallery />
         <Button href="/experiences" size="large" variant="brand">
@@ -55,6 +57,7 @@ export default function Home() {
         <SectionHeader
           kicker={t.home.restaurant.kicker}
           heading={t.home.restaurant.heading}
+          size="medium"
         />
         <div className="flex flex-col items-center justify-between gap-8 lg:flex-row lg:gap-24">
           <img

--- a/pages/restaurant.tsx
+++ b/pages/restaurant.tsx
@@ -22,6 +22,7 @@ export default function Restaurant() {
           <SectionHeader
             heading={t.restaurant.heading}
             subheading={t.restaurant.subheading}
+            size="medium"
           />
         </Container>
         <div className="no-scrollbar grid snap-x snap-mandatory auto-cols-[80%] grid-flow-col gap-8 overflow-x-auto pb-12 lg:auto-cols-[40%]">

--- a/pages/terms.tsx
+++ b/pages/terms.tsx
@@ -19,7 +19,7 @@ export default function Terms() {
         <section className="flex flex-col items-center gap-12 px-6 py-16 lg:gap-16">
           {sections.map((section, index) => (
             <section key={index} className="flex flex-col gap-4">
-              <h1 className="font-display text-display-small text-foreground-default tracking-tight">
+              <h1 className="text-display-small text-foreground-default font-serif tracking-tight">
                 {section.title}
               </h1>
               <div className="text-foreground-strong">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -70,11 +70,11 @@
   --text-title-large--line-height: 32px;
   --text-display-small: 32px;
   --text-display-small--line-height: 40px;
-  --text-display-small--letter-spacing: -0.02em;
+  --text-display-small--letter-spacing: -0.03em;
   --text-display-medium: 48px;
   --text-display-medium--line-height: 52px;
   --text-display-medium--letter-spacing: -0.03em;
   --text-display-large: 64px;
   --text-display-large--line-height: 68px;
-  --text-display-large--letter-spacing: -0.04em;
+  --text-display-large--letter-spacing: -0.03em;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -53,8 +53,7 @@
 
   --font-*: initial;
   --font-sans: 'Montserrat';
-  --font-serif: 'Playfair Display';
-  --font-display: Fraunces;
+  --font-serif: 'Fraunces';
 
   --text-*: initial;
   --text-body-small: 12px;
@@ -71,8 +70,11 @@
   --text-title-large--line-height: 32px;
   --text-display-small: 32px;
   --text-display-small--line-height: 40px;
-  --text-display-medium: 40px;
-  --text-display-medium--line-height: 44px;
-  --text-display-large: 48px;
-  --text-display-large--line-height: 52px;
+  --text-display-small--letter-spacing: -0.02em;
+  --text-display-medium: 48px;
+  --text-display-medium--line-height: 52px;
+  --text-display-medium--letter-spacing: -0.03em;
+  --text-display-large: 64px;
+  --text-display-large--line-height: 68px;
+  --text-display-large--letter-spacing: -0.04em;
 }


### PR DESCRIPTION
## Summary

- Replace Playfair Display with Fraunces as the serif font and update display typography tokens (sizes and letter-spacing)
- Add a `className` prop to `SectionHeader` so callers can pass external styles (used by Hero)
- Add `size` variants (`large`, `medium`, `small`) with semantic heading tags and adopt `medium` across page sections

## Testing

- [x] Verify Fraunces loads correctly on all pages
- [x] Check Hero title styling on the homepage
- [x] Confirm section headings on home, experiences, restaurant, and contacts use the expected sizes
- [x] Review terms page heading typography after font token changes


Made with [Cursor](https://cursor.com)