### PR TITLE
✨ Add lenis smooth scroll

### DIFF
--- a/components/motion/smooth-scroll.tsx
+++ b/components/motion/smooth-scroll.tsx
@@ -1,0 +1,62 @@
+import { ReactLenis, useLenis } from 'lenis/react';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+interface SmoothScrollProps {
+  children: React.ReactNode;
+}
+
+function ScrollRouteReset() {
+  const router = useRouter();
+  const lenis = useLenis();
+
+  useEffect(() => {
+    function resetScroll() {
+      lenis?.scrollTo(0, { immediate: true });
+    }
+
+    router.events.on('routeChangeComplete', resetScroll);
+
+    return () => {
+      router.events.off('routeChangeComplete', resetScroll);
+    };
+  }, [lenis, router.events]);
+
+  return null;
+}
+
+export function SmoothScroll({ children }: SmoothScrollProps) {
+  const [smooth, setSmooth] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    function updateSmooth() {
+      setSmooth(!media.matches);
+    }
+
+    updateSmooth();
+    media.addEventListener('change', updateSmooth);
+
+    return () => {
+      media.removeEventListener('change', updateSmooth);
+    };
+  }, []);
+
+  if (smooth !== true) {
+    return children;
+  }
+
+  return (
+    <ReactLenis
+      root
+      options={{
+        lerp: 0.4,
+        smoothWheel: true,
+      }}
+    >
+      <ScrollRouteReset />
+      {children}
+    </ReactLenis>
+  );
+}

--- a/hooks/use-parallax.ts
+++ b/hooks/use-parallax.ts
@@ -1,5 +1,4 @@
-import { useTransform } from 'framer-motion';
-import { useScroll } from 'motion/react';
+import { useScroll, useTransform } from 'motion/react';
 import { useRef } from 'react';
 
 export function useParallax(speed = 0.5, travel = 40) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@phosphor-icons/react": "^2.1.10",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "lenis": "^1.3.23",
         "lucide-react": "^1.18.0",
         "motion": "^12.40.0",
         "next": "^16.2.9",
@@ -1223,6 +1224,37 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/lenis": {
+      "version": "1.3.23",
+      "resolved": "https://registry.npmjs.org/lenis/-/lenis-1.3.23.tgz",
+      "integrity": "sha512-YxYq3TJqj9sJNv0V9SkyQHejt14xwyIwgDaaMK89Uf9SxQfIszu+gTQSSphh6BWlLTNVKvvXAGkg+Zf+oFIevg==",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*",
+        "playground",
+        "playground/*"
+      ],
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/darkroomengineering"
+      },
+      "peerDependencies": {
+        "@nuxt/kit": ">=3.0.0",
+        "react": ">=17.0.0",
+        "vue": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nuxt/kit": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/lightningcss": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@phosphor-icons/react": "^2.1.10",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "lenis": "^1.3.23",
     "lucide-react": "^1.18.0",
     "motion": "^12.40.0",
     "next": "^16.2.9",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,5 @@
 import { Layout } from '@/components/layouts/layout';
+import { SmoothScroll } from '@/components/motion/smooth-scroll';
 import { TranslationProvider } from '@/contexts/translation-context';
 import '@/styles/globals.css';
 import type { AppProps } from 'next/app';
@@ -9,10 +10,12 @@ export default function App({ Component, pageProps }: AppProps) {
   const { locale } = router;
 
   return (
-    <TranslationProvider locale={locale ?? 'pt'}>
-      <Layout>
-        <Component {...pageProps} />
-      </Layout>
-    </TranslationProvider>
+    <SmoothScroll>
+      <TranslationProvider locale={locale ?? 'pt'}>
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
+      </TranslationProvider>
+    </SmoothScroll>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@import 'lenis/dist/lenis.css';
 
 :root {
   --background-neutral-default: hsl(30 40% 98%);


### PR DESCRIPTION
## Summary

- Add Lenis for smooth wheel scrolling across the site, wrapped in a `SmoothScroll` provider at the app root
- Respect `prefers-reduced-motion` by skipping Lenis when the user has reduced motion enabled
- Reset scroll position to top on Next.js route changes
- Consolidate `useParallax` motion imports into a single import path

## Test plan

- [ ] Run `npm run dev` and scroll the homepage — wheel scrolling should feel smooth
- [ ] Enable "Reduce motion" in OS settings and reload — scrolling should use native behavior
- [ ] Navigate between pages — scroll position should reset to top on each route change
- [ ] Verify parallax on the hero still works as expected


Made with [Cursor](https://cursor.com)